### PR TITLE
Update README regarding vim-plug specific instructions about post-install hooks and lazy loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,16 @@
 # bharyang-vim
-Plugin to sort imports in javascript project for vim/neovim
+Plugin to sort imports in a JavaScript project for Vim/NeoVim
 
-## Install
+## Installation
 
-### Install [bharyang-cli](https://github.com/squgeim/bharyang-cli) from npm:
+bharyang-vim depends on [bharyang-cli](https://github.com/squgeim/bharyang-cli).
 
-```sh
-npm install -g bharyang-cli
-```
+### Installation with [vim-plug](https://github.com/junegunn/vim-plug)
 
-### Install from vim-plug
-
-More info on vim-plug [here](https://github.com/junegunn/vim-plug).
+[vim-plug](https://github.com/junegunn/vim-plug) can install [bharyang-cli](https://github.com/squgeim/bharyang-cli) as a post-install hook, and lazy load this plugin for JavaScript projects.
 
 ```sh
-Plug 'squgeim/bharyang-vim'
+Plug 'squgeim/bharyang-vim', { 'do': 'npm install -g bharyang-cli', 'for': ['javascript'] } 
 ```
 
 ## Usage
@@ -31,4 +27,4 @@ BharyangDesc
 
 ## Contribution
 
-The code is quite straight forward, [bharyang](https://github.com/squgeim/bharyang-cli) does all of the heavy lifting. Pull requests are always welcome.
+The code is quite straight forward, [bharyang-cli](https://github.com/squgeim/bharyang-cli) does all of the heavy lifting. Pull requests are always welcome.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ bharyang-vim depends on [bharyang-cli](https://github.com/squgeim/bharyang-cli).
 Plug 'squgeim/bharyang-vim', { 'do': 'npm install -g bharyang-cli', 'for': ['javascript'] } 
 ```
 
+For manual installations, install `bharyang-cli` from `npm`:
+```sh
+npm install -g bharyang-cli
+```
+
 ## Usage
 
 Select the import lines in visual mode. Use any of the following commands:


### PR DESCRIPTION
- Minor README changes for `vim-plug` specific information.
- Also, added a note on manual installations

Feel free to edit the wording in whatever way you prefer.