### PR TITLE
Add a Bharyang command that relies on a configuration value

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,14 @@ npm install -g bharyang-cli
 Select the import lines in visual mode. Use any of the following commands:
 
 ```
-BharyangGroup
+Bharyang
 BharyangAsc
 BharyangDesc
+BharyangGroup
+```
+The `Bharyang` command uses a configuration value to determine whether the sort should be ascending ("asc") or descending ("desc"). It is ascending by default. Configure it using:
+```vim
+let g:bharyang_default_sort_type="desc"
 ```
 
 <img src="https://media.giphy.com/media/PR88YW3eX7Y4Rr6fkZ/giphy.gif" />

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ BharyangAsc
 BharyangDesc
 BharyangGroup
 ```
-The `Bharyang` command uses a configuration value to determine whether the sort should be ascending ("asc") or descending ("desc"). It is ascending by default. Configure it using:
+The `Bharyang` command uses a configuration value to determine default sort type. The value can be one of `asc`, `desc` or `group`. For example, to set it to `desc`:
 ```vim
 let g:bharyang_default_sort_type="desc"
 ```

--- a/plugin/bharyang-vim.vim
+++ b/plugin/bharyang-vim.vim
@@ -1,4 +1,9 @@
 " =========================
+" SECTION: Globals
+" =========================
+let g:bharyang_default_sort_type = "asc"
+
+" =========================
 " SECTION: Constants
 " =========================
 "
@@ -32,6 +37,7 @@ endfunction
 " SECTION: Public API
 " ========================
 
+command! -range Bharyang <line1>,<line2>call s:Bharyang(g:bharyang_default_sort_type)
 command! -range BharyangAsc <line1>,<line2>call s:Bharyang(s:asc)
 command! -range BharyangDesc <line1>,<line2>call s:Bharyang(s:desc)
 command! -range BharyangGroup <line1>,<line2>call s:Bharyang(s:group)

--- a/plugin/bharyang-vim.vim
+++ b/plugin/bharyang-vim.vim
@@ -16,6 +16,13 @@ let s:group = "group"
 " =========================
 
 function! s:Bharyang(type) range
+  " Check if the type is valid, because the user exposed global sort type might change it to something else.
+  if a:type !=# s:asc && a:type !=# s:desc && a:type !=# s:group
+    echoe "Sort type ".a:type." is not compatible with Bharyang. Use one of `asc`, `desc` or `group`."
+
+    return
+  endif
+
   if executable('bharyang')
     let l:sortedlines = s:SortLines(a:type, getline(a:firstline, a:lastline))
     let l:totallines = a:lastline - a:firstline + 1


### PR DESCRIPTION
The rationale behind this is that using `BharyangAsc`, `BharyangDesc` or `BharyangGroup` requires one tab too many.

The general flow, post visual selection(for me at least) is:
```
:'<,'>bh<tab>
```
Now, it prompts me to choose between the 3 options (because practically everyone has `wildmenu` enabled). Realistically, only one of these 3 would be the high frequency use-case?

A default `Bharyang` with a configurable sort type solves this because not every command needs a custom binding 😄 

I'm not sure whether `bharyang-cli` supports case-insensitive values for the `type`, so I've defensively used a case-sensitive equality check.